### PR TITLE
fix: adjust Hue ranges for better ripe banana detection

### DIFF
--- a/internal/handler/fruit.go
+++ b/internal/handler/fruit.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"fruit-analyzer-api/internal/analyzer"
@@ -44,6 +45,16 @@ func (h *FruitHandler) HandleAnalyze(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	response := struct {
+		Status string `json:"status"`
+	}{
+		Status: status,
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"status": "` + status + `"}`))
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		h.logger.Error("Erro ao enviar resposta", zap.Error(err))
+		http.Error(w, "Erro ao enviar resposta", http.StatusInternalServerError)
+		return
+	}
 }


### PR DESCRIPTION
## Changes
- Refined the HSV color ranges to improve accuracy in detecting banana ripeness stages
- Adjusted the Hue value ranges for each ripeness stage:
  - Green: 50-80 (previously 40-80)
  - Ripe: 35-55 (previously 30-45)
  - Overripe: 15-35 (previously 15-30)
- Improved JSON response handling in the fruit handler using proper JSON encoding
